### PR TITLE
Initialize monorepo skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+packages/*/dist

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Repo Guidelines
+
+- Use `pnpm` for all package management.
+- Run `pnpm install` and `pnpm test` before committing if tests exist.
+- Keep documentation updated in README files.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,1 @@
+This monorepo contains three packages providing various distributions of the FeedbackIt widget: a React component, a vanilla JS build and a WordPress plugin.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,0 +1,1 @@
+Document important project decisions here.

--- a/FEEDBACK.md
+++ b/FEEDBACK.md
@@ -1,0 +1,1 @@
+Feedback and user input will be tracked here.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# feedbackit-widget
+# FeedbackIt Widget Monorepo
+
+This repository hosts the source code for multiple distribution formats of the FeedbackIt widget. Each package lives in `packages/` and is published independently.
+
+- **react** – React component published as `@feedbackit/widget`.
+- **vanilla** – Stand‑alone JS build published as `@feedbackit/widget-html`.
+- **wordpress** – WordPress plugin to easily embed the widget.
+
+Use `pnpm` for dependency management and running scripts.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,1 @@
+- [ ] Initial skeleton of React, Vanilla and WordPress packages.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "feedbackit-widget-monorepo",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "packages/react",
+    "packages/vanilla",
+    "packages/wordpress"
+  ],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "pnpm -r run test"
+  }
+}

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,0 +1,11 @@
+# @feedbackit/widget
+
+React component for displaying FeedbackIt alerts and feedback form.
+
+## Usage
+
+```jsx
+import { FeedbackItWidget } from '@feedbackit/widget';
+
+<FeedbackItWidget projectId="abc123" />
+```

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@feedbackit/widget",
+  "version": "0.1.0",
+  "main": "dist/index.cjs.js",
+  "module": "dist/index.esm.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc && vite build",
+    "test": "echo 'no tests'"
+  },
+  "peerDependencies": {
+    "react": ">=17",
+    "react-dom": ">=17"
+  }
+}

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -1,0 +1,39 @@
+import React, { useState, useEffect } from 'react';
+
+export interface FeedbackItWidgetProps {
+  projectId: string;
+  lang?: string;
+  showFeedbackButton?: boolean;
+  pollAlerts?: boolean;
+}
+
+export const FeedbackItWidget: React.FC<FeedbackItWidgetProps> = ({ projectId, lang = 'en', showFeedbackButton = true, pollAlerts = true }) => {
+  const [alert, setAlert] = useState<any>(null);
+  const [showForm, setShowForm] = useState(false);
+  useEffect(() => {
+    if (!pollAlerts) return;
+    fetch(`https://api.feedbackit.io/alerts?projectId=${projectId}`)
+      .then(r => r.json())
+      .then(a => setAlert(a.active ? a : null))
+      .catch(() => {});
+  }, [projectId, pollAlerts]);
+  return (
+    <div className="feedbackit-widget">
+      {alert && (
+        <div className={`fi-alert fi-${alert.type}`}>{alert.message}</div>
+      )}
+      {showFeedbackButton && (
+        <button className="fi-btn" onClick={() => setShowForm(true)}>Donner un avis</button>
+      )}
+      {showForm && (
+        <form onSubmit={e => { e.preventDefault(); setShowForm(false); }}>
+          <textarea name="message" placeholder="Votre avis" />
+          <input type="file" name="file" />
+          <button type="submit">Envoyer</button>
+        </form>
+      )}
+    </div>
+  );
+};
+
+export default FeedbackItWidget;

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "declaration": true,
+    "outDir": "../dist",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": ["src"]
+}

--- a/packages/vanilla/README.md
+++ b/packages/vanilla/README.md
@@ -1,0 +1,10 @@
+# @feedbackit/widget-html
+
+Vanilla JS build of the FeedbackIt widget. Use in any webpage.
+
+```html
+<script src="widget.js"></script>
+<script>
+  FeedbackItWidget.init({ projectId: 'abc123' });
+</script>
+```

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@feedbackit/widget-html",
+  "version": "0.1.0",
+  "main": "dist/widget.umd.js",
+  "scripts": {
+    "build": "vite build",
+    "test": "echo 'no tests'"
+  }
+}

--- a/packages/vanilla/src/widget.js
+++ b/packages/vanilla/src/widget.js
@@ -1,0 +1,22 @@
+(function (global) {
+  function init(options) {
+    var projectId = options.projectId;
+    fetch('https://api.feedbackit.io/alerts?projectId=' + projectId)
+      .then(function (r) { return r.json(); })
+      .then(function (a) {
+        if (a.active) {
+          var div = document.createElement('div');
+          div.className = 'fi-alert fi-' + a.type;
+          div.textContent = a.message;
+          document.body.appendChild(div);
+        }
+      });
+    var btn = document.createElement('button');
+    btn.textContent = 'Donner un avis';
+    btn.onclick = function () {
+      alert('TODO: open feedback form');
+    };
+    document.body.appendChild(btn);
+  }
+  global.FeedbackItWidget = { init: init };
+})(this);

--- a/packages/wordpress/README.md
+++ b/packages/wordpress/README.md
@@ -1,0 +1,5 @@
+# FeedbackIt WordPress Plugin
+
+Installs the FeedbackIt widget on your WordPress site.
+
+Upload the plugin folder as a zip and configure your project ID in the settings page.

--- a/packages/wordpress/feedbackit-widget.php
+++ b/packages/wordpress/feedbackit-widget.php
@@ -1,0 +1,30 @@
+<?php
+/*
+Plugin Name: FeedbackIt Widget
+Description: Embeds the FeedbackIt widget via CDN.
+Version: 0.1.0
+*/
+
+function feedbackit_widget_script() {
+    $projectId = get_option('feedbackit_project_id', '');
+    if ($projectId) {
+        echo "<script src='https://unpkg.com/@feedbackit/widget-html/dist/widget.umd.js'></script>\n";
+        echo "<script>FeedbackItWidget.init({ projectId: '" . esc_js($projectId) . "' });</script>\n";
+    }
+}
+add_action('wp_footer', 'feedbackit_widget_script');
+
+function feedbackit_widget_settings_page() {
+    add_options_page('FeedbackIt Widget', 'FeedbackIt Widget', 'manage_options', 'feedbackit-widget', 'feedbackit_widget_settings_html');
+}
+add_action('admin_menu', 'feedbackit_widget_settings_page');
+
+function feedbackit_widget_settings_html() {
+    if (isset($_POST['feedbackit_project_id'])) {
+        update_option('feedbackit_project_id', sanitize_text_field($_POST['feedbackit_project_id']));
+        echo '<div class="updated"><p>Saved</p></div>';
+    }
+    $val = esc_attr(get_option('feedbackit_project_id', ''));
+    echo '<form method="post"><input type="text" name="feedbackit_project_id" value="' . $val . '" /><input type="submit" value="Save" /></form>';
+}
+?>

--- a/packages/wordpress/readme.txt
+++ b/packages/wordpress/readme.txt
@@ -1,0 +1,8 @@
+=== FeedbackIt Widget ===
+Contributors: feedbackit
+Tags: feedback
+Requires at least: 5.0
+Tested up to: 6.0
+Stable tag: 0.1.0
+
+Simple plugin that injects the FeedbackIt widget.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'packages/*'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    lib: {
+      entry: 'packages/react/src/index.tsx',
+      name: 'FeedbackItWidget',
+      fileName: (format) => `feedbackit-widget.${format}.js`
+    },
+    rollupOptions: {
+      external: ['react', 'react-dom']
+    },
+    outDir: 'packages/react/dist'
+  }
+});


### PR DESCRIPTION
## Summary
- set up root pnpm workspace and docs
- add React widget package with TypeScript source
- add vanilla JS package and global init entry
- add WordPress plugin to load the widget
- document repository guidelines in AGENTS

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/react: Forbidden)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_687df4c5fc24832ab76d30dc72c1ecc4