### PR TITLE
Enable multilingual widget

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,4 @@
 - Use `pnpm` for all package management.
 - Run `pnpm install` and `pnpm test` before committing if tests exist.
 - Keep documentation updated in README files.
+- New features should provide multilingual support via detection or configuration when applicable.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,1 +1,3 @@
 This monorepo contains three packages providing various distributions of the FeedbackIt widget: a React component, a vanilla JS build and a WordPress plugin.
+
+The widget now supports multilingual usage (English and French). Each package can automatically detect the browser language or accept a configuration option to set it explicitly.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,1 +1,3 @@
 Document important project decisions here.
+
+- Added built-in multilingual support (English/French) with automatic detection and optional configuration.

--- a/FEEDBACK.md
+++ b/FEEDBACK.md
@@ -1,1 +1,3 @@
 Feedback and user input will be tracked here.
+
+- Users requested support for multiple languages.

--- a/README.md
+++ b/README.md
@@ -7,3 +7,6 @@ This repository hosts the source code for multiple distribution formats of the F
 - **wordpress** – WordPress plugin to easily embed the widget.
 
 Use `pnpm` for dependency management and running scripts.
+
+All packages support English and French out of the box. The widget detects the
+browser language by default and can be configured explicitly when embedding.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,1 +1,2 @@
 - [ ] Initial skeleton of React, Vanilla and WordPress packages.
+- [x] Add multilingual detection and configuration (English/French).

--- a/WIREFRAMES/multilang.md
+++ b/WIREFRAMES/multilang.md
@@ -1,0 +1,2 @@
+# Multilingual configuration
+Simple mockup showing dropdown for language selection in the widget settings.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -9,3 +9,12 @@ import { FeedbackItWidget } from '@feedbackit/widget';
 
 <FeedbackItWidget projectId="abc123" />
 ```
+
+### Language
+
+The widget automatically detects the browser language (English or French).
+Override detection using the `lang` prop:
+
+```jsx
+<FeedbackItWidget projectId="abc123" lang="fr" />
+```

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -7,7 +7,28 @@ export interface FeedbackItWidgetProps {
   pollAlerts?: boolean;
 }
 
-export const FeedbackItWidget: React.FC<FeedbackItWidgetProps> = ({ projectId, lang = 'en', showFeedbackButton = true, pollAlerts = true }) => {
+const translations = {
+  en: {
+    feedbackButton: 'Give feedback',
+    placeholder: 'Your feedback',
+    send: 'Send'
+  },
+  fr: {
+    feedbackButton: 'Donner un avis',
+    placeholder: 'Votre avis',
+    send: 'Envoyer'
+  }
+};
+
+function detectLang(prop?: string): keyof typeof translations {
+  if (prop && translations[prop as keyof typeof translations]) return prop as keyof typeof translations;
+  if (typeof navigator !== 'undefined' && navigator.language.startsWith('fr')) return 'fr';
+  return 'en';
+}
+
+export const FeedbackItWidget: React.FC<FeedbackItWidgetProps> = ({ projectId, lang, showFeedbackButton = true, pollAlerts = true }) => {
+  const locale = detectLang(lang);
+  const t = translations[locale];
   const [alert, setAlert] = useState<any>(null);
   const [showForm, setShowForm] = useState(false);
   useEffect(() => {
@@ -23,13 +44,13 @@ export const FeedbackItWidget: React.FC<FeedbackItWidgetProps> = ({ projectId, l
         <div className={`fi-alert fi-${alert.type}`}>{alert.message}</div>
       )}
       {showFeedbackButton && (
-        <button className="fi-btn" onClick={() => setShowForm(true)}>Donner un avis</button>
+        <button className="fi-btn" onClick={() => setShowForm(true)}>{t.feedbackButton}</button>
       )}
       {showForm && (
         <form onSubmit={e => { e.preventDefault(); setShowForm(false); }}>
-          <textarea name="message" placeholder="Votre avis" />
+          <textarea name="message" placeholder={t.placeholder} />
           <input type="file" name="file" />
-          <button type="submit">Envoyer</button>
+          <button type="submit">{t.send}</button>
         </form>
       )}
     </div>

--- a/packages/vanilla/README.md
+++ b/packages/vanilla/README.md
@@ -8,3 +8,14 @@ Vanilla JS build of the FeedbackIt widget. Use in any webpage.
   FeedbackItWidget.init({ projectId: 'abc123' });
 </script>
 ```
+
+### Language
+
+Language defaults to the browser setting (English or French). Override with the
+`lang` option:
+
+```html
+<script>
+  FeedbackItWidget.init({ projectId: 'abc123', lang: 'fr' });
+</script>
+```

--- a/packages/vanilla/src/widget.js
+++ b/packages/vanilla/src/widget.js
@@ -1,6 +1,18 @@
 (function (global) {
+  var translations = {
+    en: { feedbackButton: 'Give feedback' },
+    fr: { feedbackButton: 'Donner un avis' }
+  };
+
+  function detectLang(lang) {
+    if (lang && translations[lang]) return lang;
+    if (navigator.language && navigator.language.indexOf('fr') === 0) return 'fr';
+    return 'en';
+  }
+
   function init(options) {
     var projectId = options.projectId;
+    var lang = detectLang(options.lang);
     fetch('https://api.feedbackit.io/alerts?projectId=' + projectId)
       .then(function (r) { return r.json(); })
       .then(function (a) {
@@ -12,7 +24,7 @@
         }
       });
     var btn = document.createElement('button');
-    btn.textContent = 'Donner un avis';
+    btn.textContent = translations[lang].feedbackButton;
     btn.onclick = function () {
       alert('TODO: open feedback form');
     };

--- a/packages/wordpress/README.md
+++ b/packages/wordpress/README.md
@@ -3,3 +3,5 @@
 Installs the FeedbackIt widget on your WordPress site.
 
 Upload the plugin folder as a zip and configure your project ID in the settings page.
+
+The settings page also allows choosing the widget language (English or French) or using automatic browser detection.

--- a/packages/wordpress/feedbackit-widget.php
+++ b/packages/wordpress/feedbackit-widget.php
@@ -7,9 +7,13 @@ Version: 0.1.0
 
 function feedbackit_widget_script() {
     $projectId = get_option('feedbackit_project_id', '');
+    $lang = get_option('feedbackit_lang', '');
     if ($projectId) {
         echo "<script src='https://unpkg.com/@feedbackit/widget-html/dist/widget.umd.js'></script>\n";
-        echo "<script>FeedbackItWidget.init({ projectId: '" . esc_js($projectId) . "' });</script>\n";
+        $args = "{ projectId: '" . esc_js($projectId) . "'";
+        if ($lang) { $args .= ", lang: '" . esc_js($lang) . "'"; }
+        $args .= " }";
+        echo "<script>FeedbackItWidget.init($args);</script>\n";
     }
 }
 add_action('wp_footer', 'feedbackit_widget_script');
@@ -22,9 +26,19 @@ add_action('admin_menu', 'feedbackit_widget_settings_page');
 function feedbackit_widget_settings_html() {
     if (isset($_POST['feedbackit_project_id'])) {
         update_option('feedbackit_project_id', sanitize_text_field($_POST['feedbackit_project_id']));
+        update_option('feedbackit_lang', sanitize_text_field($_POST['feedbackit_lang']));
         echo '<div class="updated"><p>Saved</p></div>';
     }
-    $val = esc_attr(get_option('feedbackit_project_id', ''));
-    echo '<form method="post"><input type="text" name="feedbackit_project_id" value="' . $val . '" /><input type="submit" value="Save" /></form>';
+    $projectVal = esc_attr(get_option('feedbackit_project_id', ''));
+    $langVal = esc_attr(get_option('feedbackit_lang', ''));
+    echo '<form method="post">';
+    echo '<p>Project ID: <input type="text" name="feedbackit_project_id" value="' . $projectVal . '" /></p>';
+    echo '<p>Language: <select name="feedbackit_lang">';
+    echo '<option value="">Auto</option>';
+    echo '<option value="en"' . selected($langVal, 'en', false) . '>English</option>';
+    echo '<option value="fr"' . selected($langVal, 'fr', false) . '>Français</option>';
+    echo '</select></p>';
+    echo '<p><input type="submit" value="Save" /></p>';
+    echo '</form>';
 }
 ?>


### PR DESCRIPTION
## Summary
- add English/French detection logic across widgets
- allow configuring language in WordPress plugin settings
- document multilingual options in READMEs
- record decision and roadmap progress
- update repo guidelines and wireframes

## Testing
- `pnpm install` *(fails: ERR_PNPM_FETCH_403)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_687df852eb00832aaf5f87eb8d6375ee